### PR TITLE
Improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,18 @@ The produced artifacts will have the classifier in the name of the spring boot u
  ## Running Backend
  
  At present running the app requires the following:
-  S3 bucket (djl-demo by default) specified in djl-spring-boot-app/src/main/resources/application.properties.
-  The bucket is expected to have two prefixes: inbox (where input is located) and outbox (where results are placed)
-  AWS_ACCESS_KEY and AWS_SECRET_KEY set as environment variables. IAM user is expected to have read permissions for inbox and write permission for outbox.
+  S3 bucket (`djl-demo` by default) specified in `djl-spring-boot-app/src/main/resources/application.properties`.
+  The bucket is expected to have two prefixes: `inbox` (where input is located) and `outbox` (where results are placed)
+  `AWS_ACCESS_KEY` and `AWS_SECRET_KEY` set as environment variables for region `us-east-1`. 
+  The IAM user is expected to have read permissions for `inbox` and write permission for `outbox`.
   
-  macOS:
-  
+  Run the following command to start the backend based on the created JAR file, sample command for macOS:
+      
     java -jar djl-spring-boot-app/build/libs/djl-spring-boot-app-0.0.1-SNAPSHOT-osx-x86_64.jar
+  
+  Alternatively you can use Gradle for execution, sample command for Windows:   
+  
+    gradlew :djl-spring-boot-app:bootRun -P osclassifier=win-x86_64
   
 ## Deploying to PCF
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,12 +27,12 @@ subprojects {
         mavenCentral()
     }
 
-    java.sourceCompatibility=JavaVersion.VERSION_12
-    java.targetCompatibility=JavaVersion.VERSION_12
+    java.sourceCompatibility=JavaVersion.VERSION_11
+    java.targetCompatibility=JavaVersion.VERSION_11
 
     dependencyManagement {
         imports {
-            mavenBom("org.springframework:spring-framework-bom:5.2.3.RELEASE")
+            mavenBom("org.springframework:spring-framework-bom:5.2.8.RELEASE")
         }
     }
 }

--- a/djl-spring-boot-web/README.md
+++ b/djl-spring-boot-web/README.md
@@ -1,4 +1,8 @@
 # DJL Demo Web Application
+To run the web application directly execute:
+
+    gradlew :djl-spring-boot-web:bootRun
+
 To deploy to PCF edit `manifest.yml` and supply access key and secret key that allow access to the desired S3 bucket.
 The bucket name is set to `djl-demo` in application.properties file. 
 

--- a/djl-spring-boot-web/build.gradle.kts
+++ b/djl-spring-boot-web/build.gradle.kts
@@ -38,6 +38,6 @@ tasks.withType<Test> {
 tasks.withType<KotlinCompile> {
 	kotlinOptions {
 		freeCompilerArgs = listOf("-Xjsr305=strict")
-		jvmTarget = "12"
+		jvmTarget = "11"
 	}
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Hi,
I haven't found a good reason why Java 12 should be required and it is end of life soon, so I set it to 11 (this is a LTS version) to be able to run it with Amazon Corretto. Besides that I aligned the Spring Framework version with the one used by Spring Boot and slightly improved the docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
